### PR TITLE
fix missing <cstdint> include causing uint32_t compile error

### DIFF
--- a/src/model.cpp
+++ b/src/model.cpp
@@ -1,4 +1,5 @@
 #include "model.hpp"
+#include <cstdint>
 #include <fstream>
 #include <sstream>
 #include <iostream>


### PR DESCRIPTION
## fix

> OS - fedora

Fixes a compilation error caused by a missing `<cstdint>` include in model.cpp.

`uint32_t` was used in `Model::loadFromStl` but the header defining fixed-width integer types was not included, causing the build to fail on stricter compilers.

Changes

Added `#include <cstdint>` to src/model.cpp

Compilation failed with errors:
```
error: ‘uint32_t’ was not declared in this scope
note: ‘uint32_t’ is defined in header ‘<cstdint>’
```

After adding the `include` statement, it compiles properly.



